### PR TITLE
Update plex_meta_manager.py

### DIFF
--- a/plex_meta_manager.py
+++ b/plex_meta_manager.py
@@ -63,7 +63,7 @@ libraries = get_arg("PMM_LIBRARIES", args.libraries)
 resume = get_arg("PMM_RESUME", args.resume)
 times = get_arg("PMM_TIME", args.times)
 divider = get_arg("PMM_DIVIDER", args.divider)
-screen_width = get_arg("PMM_WIDTH", args.width)
+screen_width = get_arg("PMM_WIDTH", args.width, arg_int=True)
 config_file = get_arg("PMM_CONFIG", args.config)
 stats = {}
 


### PR DESCRIPTION
I think that the above change needs to be added otherwise the comparison on line 72 fails with the following error when I set PMM_WIDTH attribute:

Traceback (most recent call last):
File "//plex_meta_manager.py", line 72, in <module>
if screen_width < 90 or screen_width > 300:
TypeError: '<' not supported between instances of 'str' and 'int'

## Description

Please include a summary of the changes.

### Issues Fixed or Closed

- Fixes #(issue)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
